### PR TITLE
Add compatibility with guzzle7 and simplify unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 vendor/
 composer.lock
+/tests/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
 		"psr-4": {"EmailOnAcid\\Tests\\": "tests/"}
 	},
 	"require": {
-		"php": ">=7.1",
-		"guzzlehttp/guzzle": "^6.2"
+		"php": ">=7.2",
+		"ext-json": "*",
+		"guzzlehttp/guzzle": "^6.0 || ^7.2"
 	},
 	"require-dev": {
-		"phpunit/phpunit" : "6.2.2",
-		"roave/better-reflection": "@dev"
+		"phpunit/phpunit" : "^8.5 || ^9.0",
+		"blastcloud/guzzler": "^1.6 || ^2.0"
 	}
 
 }

--- a/tests/ApiHelper.php
+++ b/tests/ApiHelper.php
@@ -6,6 +6,8 @@ namespace EmailOnAcid\Tests;
 
 use EmailOnAcid\Request\RequestFactory;
 use EmailOnAcid\ServiceFactory;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 trait ApiHelper
@@ -13,7 +15,7 @@ trait ApiHelper
 	/**
 	 * @param string $expects
 	 * @param array $return
-	 * @return RequestFactory|\PHPUnit_Framework_MockObject_MockObject
+	 * @return RequestFactory|MockObject
 	 */
 	private function mockRequestFactory(string $expects, $return = []): RequestFactory
 	{
@@ -21,7 +23,7 @@ trait ApiHelper
 		/** @var TestCase $this */
 		$mock = $this->getMockBuilder(RequestFactory::class)
 			->disableOriginalConstructor()
-			->setMethods($methods)->getMock();
+			->onlyMethods($methods)->getMock();
 		foreach ($methods as $method) {
 			if ($method !== $expects) {
 				$mock->method($method)->willReturn($return);
@@ -38,7 +40,7 @@ trait ApiHelper
 	 * @param null|string $method
 	 * @param null|string $class
 	 * @param mixed $return
-	 * @return ServiceFactory|\PHPUnit_Framework_MockObject_MockObject
+	 * @return ServiceFactory|MockObject
 	 * @internal param array $methods
 	 */
 	private function mockServiceFactory(?string $method, ?string $class = null, $return = null): ServiceFactory
@@ -46,7 +48,7 @@ trait ApiHelper
 		/** @var TestCase $this */
 		$mockBuilder = $this->getMockBuilder(ServiceFactory::class)
 			->disableOriginalConstructor();
-		$mockBuilder->setMethods(['createEmailTestingService', 'createTestsService', 'createEmailClientsService', 'createSpamTestingService']);
+		$mockBuilder->onlyMethods(['createEmailTestingService', 'createTestsService', 'createEmailClientsService', 'createSpamTestingService']);
 		$mock = $mockBuilder->getMock();
 
 		$spamTestingMock = $this->getMockBuilder(\EmailOnAcid\SpamTesting\Service::class)
@@ -63,19 +65,19 @@ trait ApiHelper
 		if ($method) {
 			switch ($class) {
 				case Service::class:
-					$testMock->setMethods([$method]);
+					$testMock->onlyMethods([$method]);
 					$mockExpect = $testMock = $testMock->getMock();
 					break;
 				case \EmailOnAcid\SpamTesting\Service::class:
-					$spamTestingMock->setMethods([$method]);
+					$spamTestingMock->onlyMethods([$method]);
 					$mockExpect = $spamTestingMock = $spamTestingMock->getMock();
 					break;
 				case \EmailOnAcid\EmailClients\Service::class:
-					$emailClientsMock->setMethods([$method]);
+					$emailClientsMock->onlyMethods([$method]);
 					$mockExpect = $emailClientsMock = $emailClientsMock->getMock();
 					break;
 				case \EmailOnAcid\EmailTesting\Service::class:
-					$emailTestingMock->setMethods([$method]);
+					$emailTestingMock->onlyMethods([$method]);
 					$mockExpect = $emailTestingMock = $emailTestingMock->getMock();
 					break;
 			}
@@ -94,19 +96,19 @@ trait ApiHelper
 
 		$mock->method('createEmailTestingService')
 			->willReturn(
-				$emailTestingMock
+				$emailTestingMock instanceof MockBuilder ? $emailTestingMock->getMock() : $emailTestingMock
 			);
 		$mock->method('createTestsService')
 			->willReturn(
-				$testMock
+                $testMock instanceof MockBuilder ? $testMock->getMock() : $testMock
 			);
 		$mock->method('createEmailClientsService')
 			->willReturn(
-				$emailClientsMock
+                $emailClientsMock instanceof MockBuilder ? $emailClientsMock->getMock() : $emailClientsMock
 			);
 		$mock->method('createSpamTestingService')
 			->willReturn(
-				$spamTestingMock
+                $spamTestingMock instanceof MockBuilder ? $spamTestingMock->getMock() : $spamTestingMock
 			);
 
 		return $mock;

--- a/tests/SpamTesting/ApiTest.php
+++ b/tests/SpamTesting/ApiTest.php
@@ -16,7 +16,7 @@ class ApiTest extends TestCase
 	public function testCreateSpamTest()
 	{
 		$new_spam_test = new NewSpamTest('test');
-		$spam_test = $this->getMockBuilder(SpamTestRequest::class)->disableOriginalConstructor()->setMethods(['jsonSerialize'])->getMock();
+		$spam_test = $this->getMockBuilder(SpamTestRequest::class)->disableOriginalConstructor()->onlyMethods(['jsonSerialize'])->getMock();
 		$spam_test->expects($this->once())->method('jsonSerialize');
 
 		$api = $this->mockSpamTestingApi(


### PR DESCRIPTION
This PR adds compatibility with guzzle 7. I upgraded phpunit to 8.5, but it also runs with 9.x. I also simplified some unit tests leveraging the guzzler library for guzzle testing.

Unit tests run successfully with lowest and latest deps on PHP 7.2, 7.3 and 7.4 respectively.
Please let me know if you're willing to merge this. If not, I'll have to use our fork for now, since some of the packages we need to update force us to use guzzle 7.